### PR TITLE
Completed 'Jinja' section, fixed fct_orders and documentation.

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -16,8 +16,16 @@ clean-targets:
   - "target"
   - "dbt_packages"
 
+seeds:
+  +persist_docs:
+      relation: true
+      columns: true
+
 models:
   jaffle_shop:
+    +persist_docs:
+      relation: true
+      columns: true
     staging:
       +materialized: view
     marts:

--- a/models/marts/core/core.yaml
+++ b/models/marts/core/core.yaml
@@ -1,0 +1,84 @@
+version: 2
+
+models:
+  - name: dim_customers
+    description: One line per customer.
+    columns:
+      - name: customer_id
+        description: Primary key.
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('stg_customer')
+              field: customer_id
+      - name: first_name
+        description: Customer's first name.
+      - name: last_name
+        description: Initial of customer's last name.
+      - name: first_order_date
+        description: Date of customer's first order at the Jaffle Shop.
+      - name: most_recent_order_date
+        description: Date of customer's most recent order at the Jaffle Shop.
+      - name: number_of_orders
+        description: The number of orders that customer has made at the Jaffle Shop.
+      - name: lifetime_value
+        description: Total paid amount across all of customer's orders at the Jaffle Shop.
+  - name: fct_failed_orders
+    description: One line per failed order.
+    columns:
+      - name: order_id
+        description: Primary key.
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('stg_orders')
+              field: order_id
+      - name: customer_id
+        description: ID of customer that made the attempted order (see `dim_customers`).
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id
+      - name: amount
+        description: Amount of failed order.
+  - name: fct_orders
+    description: One line per order.
+    columns:
+      - name: order_id
+        description: Primary key.
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('stg_orders')
+              field: order_id
+      - name: customer_id
+        description: ID of customer that made the order (see `dim_customers`).
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id
+      - name: amount
+        description: Order amount.
+  - name: int_orders__pivoted
+    description: One line per order. Payment methods separated into different columns.
+    columns:
+      - name: order_id
+        description: Primary key.
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('stg_orders')
+              field: order_id
+      - name: customer_id
+        description: ID of customer that made the order (see `dim_customers`).
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id

--- a/models/marts/core/fct_orders.sql
+++ b/models/marts/core/fct_orders.sql
@@ -1,2 +1,3 @@
-select order_id, customer_id, amount
+select order_id, any_value(customer_id) as customer_id, sum(amount) as amount
 from {{ ref('stg_orders') }} inner join {{ ref('stg_payments_successful') }} using (order_id)
+group by order_id

--- a/models/marts/core/int_orders__pivoted.sql
+++ b/models/marts/core/int_orders__pivoted.sql
@@ -1,0 +1,13 @@
+{%- set possible_payment_methods = ['credit_card', 'bank_transfer', 'coupon', 'gift_card'] -%}
+
+select
+    order_id,
+    any_value(customer_id) as customer_id,
+    {%- for method in possible_payment_methods %}
+    sum(case when payment_method = '{{method}}' then amount else 0 end) as amount_by_{{method}}
+    {%- if not loop.last -%} , {%- endif %}
+    {%- endfor %}
+
+from {{ ref('stg_orders') }} inner join {{ ref('stg_payments_successful') }} using (order_id)
+
+group by order_id

--- a/seeds/schema.yaml
+++ b/seeds/schema.yaml
@@ -3,7 +3,7 @@ version: 2
 seeds:
   - name: employees
     description: A table of employees at the Jaffle Shop, referenced to their customer_id.
-    - columns:
+    columns:
       - name: employee_id
         description: Primary key.
         tests:
@@ -17,4 +17,3 @@ seeds:
           - relationships:
               to: ref('stg_customers')
               field: customer_id
-          


### PR DESCRIPTION
* New model int_orders__pivoted defined using Jinja.
* Fixed fct_orders to group by order_id instead of be one line per transaction.
* Documented the 'core' mart.
* Misc fix to YAML in schema.yaml.
* Added +persist_docs so that table and column descriptions propagate to BigQuery.